### PR TITLE
Multiple fixes

### DIFF
--- a/tool_changing_capability/move_group_capability_plugin_description.xml
+++ b/tool_changing_capability/move_group_capability_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="moveit_move_group_tool_changing_capability">
+<library path="move_group_tool_changing_capability">
     <class name="move_group/ToolChangingCapability" type="move_group::ToolChangingCapability" base_class_type="move_group::MoveGroupCapability">
         <description>
             MoveGroup capability to dynamically change the end-effector

--- a/tool_changing_capability/src/tool_changing_capability.cpp
+++ b/tool_changing_capability/src/tool_changing_capability.cpp
@@ -87,12 +87,13 @@ void ToolChangingCapability::changeEndEffectorCB(
 
 bool ToolChangingCapability::enableEndEffector(const std::string& end_effector)
 {
-  if (!robot_model_->hasEndEffector(end_effector))
+  if (!end_effector.empty() && !robot_model_->hasEndEffector(end_effector))
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Unknown end-effector `" << end_effector << "`");
     return false;
   }
-  RCLCPP_INFO_STREAM(LOGGER, "Setting current end-effector to `" << end_effector << "`");
+  RCLCPP_INFO_STREAM_EXPRESSION(LOGGER, !end_effector.empty(),
+                                "Setting current end-effector to `" << end_effector << "`");
   planning_scene_monitor::LockedPlanningSceneRW scene(context_->planning_scene_monitor_);
   auto& acm = scene->getAllowedCollisionMatrixNonConst();
   acm = cached_acm_;

--- a/tool_changing_capability/src/tool_changing_capability.hpp
+++ b/tool_changing_capability/src/tool_changing_capability.hpp
@@ -56,6 +56,7 @@ private:
   std::string current_end_effector;
   rclcpp::CallbackGroup::SharedPtr callback_group_;
   // Enable the input end-effector and disable the other remaining ones
+  // If the end-effector name is an empty string disable all end-effectors
   bool enableEndEffector(const std::string& end_effector);
 };
 }  // namespace move_group


### PR DESCRIPTION
- Fix library name
- Sending a request with an empty end-effector name disable all of them
- Simplify disabling collisions
