### PR TITLE
Add CI configuration for rolling

### DIFF
--- a/.github/workflows/rolling_build_and_test.yaml
+++ b/.github/workflows/rolling_build_and_test.yaml
@@ -1,0 +1,38 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: Build and Test
+
+# This determines when this workflow is run
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  industrial_ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - CI_NAME: clang-format
+            CLANG_FORMAT_CHECK: file
+            CLANG_FORMAT_VERSION: 10
+          - CI_NAME: build-and-test
+          - CI_NAME: clang-tidy
+            CLANG_TIDY: true
+
+    env:
+      CXXFLAGS: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
+
+      ROS_DISTRO: rolling
+      ROS_REPO: main
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Run industrial_ci
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{ matrix.env }}

--- a/.github/workflows/rolling_build_and_test.yaml
+++ b/.github/workflows/rolling_build_and_test.yaml
@@ -1,7 +1,7 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: Build and Test
+name: Rolling build and Test
 
 # This determines when this workflow is run
 on:


### PR DESCRIPTION
Closes #6 

I am starting this because on the new version of rolling I am unable to build package locally.